### PR TITLE
(minor) Java example typo and redundant if

### DIFF
--- a/Java/FastNoiseLite.java
+++ b/Java/FastNoiseLite.java
@@ -126,7 +126,7 @@ public class FastNoiseLite
     private float mLacunarity = 2.0f;
     private float mGain = 0.5f;
     private float mWeightedStrength = 0.0f;
-    private float mPingPongStength = 2.0f;
+    private float mPingPongStrength = 2.0f;
 
     private float mFractalBounding = 1 / 1.75f;
 
@@ -249,7 +249,7 @@ public class FastNoiseLite
     /// <remarks>
     /// Default: 2.0
     /// </remarks>
-    public void SetFractalPingPongStrength(float pingPongStrength) { mPingPongStength = pingPongStrength; }
+    public void SetFractalPingPongStrength(float pingPongStrength) { mPingPongStrength = pingPongStrength; }
 
 
     /// <summary>
@@ -879,7 +879,7 @@ public class FastNoiseLite
 
         for (int i = 0; i < mOctaves; i++)
         {
-            float noise = PingPong((GenNoiseSingle(seed++, x, y) + 1) * mPingPongStength);
+            float noise = PingPong((GenNoiseSingle(seed++, x, y) + 1) * mPingPongStrength);
             sum += (noise - 0.5f) * 2 * amp;
             amp *= Lerp(1.0f, noise, mWeightedStrength);
 
@@ -899,7 +899,7 @@ public class FastNoiseLite
 
         for (int i = 0; i < mOctaves; i++)
         {
-            float noise = PingPong((GenNoiseSingle(seed++, x, y, z) + 1) * mPingPongStength);
+            float noise = PingPong((GenNoiseSingle(seed++, x, y, z) + 1) * mPingPongStrength);
             sum += (noise - 0.5f) * 2 * amp;
             amp *= Lerp(1.0f, noise, mWeightedStrength);
 
@@ -1508,11 +1508,7 @@ public class FastNoiseLite
         if (mCellularDistanceFunction == CellularDistanceFunction.Euclidean && mCellularReturnType != CellularReturnType.CellValue)
         {
             distance0 = FastSqrt(distance0);
-
-            if (mCellularReturnType != CellularReturnType.CellValue)
-            {
-                distance1 = FastSqrt(distance1);
-            }
+            distance1 = FastSqrt(distance1);
         }
 
         switch (mCellularReturnType)
@@ -1661,11 +1657,7 @@ public class FastNoiseLite
         if (mCellularDistanceFunction == CellularDistanceFunction.Euclidean && mCellularReturnType != CellularReturnType.CellValue)
         {
             distance0 = FastSqrt(distance0);
-
-            if (mCellularReturnType != CellularReturnType.CellValue)
-            {
-                distance1 = FastSqrt(distance1);
-            }
+            distance1 = FastSqrt(distance1);
         }
 
         switch (mCellularReturnType)


### PR DESCRIPTION
Removed if checks that always defaulted to true, renamed mPingPongStength parameter to mPingPongStrength. This is an minor performance improvement and minor stylistic update.