### PR TITLE
Fix example code in Cpp/README.md

### DIFF
--- a/Cpp/README.md
+++ b/Cpp/README.md
@@ -8,7 +8,7 @@ FastNoiseLite noise;
 noise.SetNoiseType(FastNoiseLite::NoiseType_OpenSimplex2);
 
 // Gather noise data
-std::vector<float> noiseData(128 * 128)
+std::vector<float> noiseData(128 * 128);
 int index = 0;
 
 for (int y = 0; y < 128; y++)


### PR DESCRIPTION
Example code written in Cpp/README.md is missing a semicolon.