### PR TITLE
Fix example code in README.md

### DIFF
--- a/Cpp/README.md
+++ b/Cpp/README.md
@@ -15,7 +15,9 @@ for (int y = 0; y < 128; y++)
 {
     for (int x = 0; x < 128; x++)
     {
-        noiseData[index++] = noise.GetNoise((float)x, (float)y);
+        noiseData[index] = noise.GetNoise((float)x, (float)y);
+        
+        index++;
     }
 }
 


### PR DESCRIPTION
The for loop in example code is wrong, since the index always stays at 0 and results in all 0.0 values