### PR TITLE
Made cellular jitter constant consistent for all languages

### DIFF
--- a/C/FastNoiseLite.h
+++ b/C/FastNoiseLite.h
@@ -1408,7 +1408,7 @@ static float _fnlSingleCellular2D(fnl_state *state, int seed, FNLfloat x, FNLflo
     float distance1 = FLT_MAX;
     int closestHash = 0;
 
-    float cellularJitter = 0.5f * state->cellular_jitter_mod;
+    float cellularJitter = 0.43701595f * state->cellular_jitter_mod;
 
     int xPrimed = (xr - 1) * PRIME_X;
     int yPrimedBase = (yr - 1) * PRIME_Y;

--- a/GLSL/FastNoiseLite.glsl
+++ b/GLSL/FastNoiseLite.glsl
@@ -1024,7 +1024,7 @@ float _fnlSingleCellular2D(fnl_state state, int seed, FNLfloat x, FNLfloat y)
     float distance1 = 1e10f;
     int closestHash = 0;
 
-    float cellularJitter = 0.5f * state.cellular_jitter_mod;
+    float cellularJitter = 0.43701595f * state.cellular_jitter_mod;
 
     int xPrimed = (xr - 1) * PRIME_X;
     int yPrimedBase = (yr - 1) * PRIME_Y;

--- a/HLSL/FastNoiseLite.hlsl
+++ b/HLSL/FastNoiseLite.hlsl
@@ -1295,7 +1295,7 @@ static float _fnlSingleCellular2D(fnl_state state, int seed, FNLfloat x, FNLfloa
     float distance1 = 1e10f;
     int closestHash = 0;
 
-    float cellularJitter = 0.5f * state.cellular_jitter_mod;
+    float cellularJitter = 0.43701595f * state.cellular_jitter_mod;
 
     int xPrimed = (xr - 1) * PRIME_X;
     int yPrimedBase = (yr - 1) * PRIME_Y;


### PR DESCRIPTION
This PR simply adds consistency to a constant value used by the 2D cellular algorithm. The C version and GLSL/HLSL ports baed on it use a value of `0.5` instead of `0.43701595`, resulting in inconsistent output with the same inputs based on the language used.

This PR addresses #115. 