### PR TITLE
Rust - Update README.md to use correct method

### DIFF
--- a/Rust/README.md
+++ b/Rust/README.md
@@ -30,7 +30,7 @@ use fastnoise_lite::*;
 
 // Create and configure FastNoise object
 let mut noise = FastNoiseLite::new();
-noise.set_noise_type(NoiseType::OpenSimplex2);
+noise.set_noise_type(Some(NoiseType::OpenSimplex2));
 
 const WIDTH: usize = 128;
 const HEIGHT: usize = 128;

--- a/Rust/README.md
+++ b/Rust/README.md
@@ -30,7 +30,7 @@ use fastnoise_lite::*;
 
 // Create and configure FastNoise object
 let mut noise = FastNoiseLite::new();
-noise.SetNoiseType(NoiseType::OpenSimplex2);
+noise.set_noise_type(NoiseType::OpenSimplex2);
 
 const WIDTH: usize = 128;
 const HEIGHT: usize = 128;


### PR DESCRIPTION
Hello! I was trying the example given in the Getting Started section of README and it looks like `SetNoiseType` method has been renamed to `set_noise_type` and the method signature seems to take `Option<NoiseType>` as an argument.