### PR TITLE
Bug fixes for OpenSimplex2S Noise 2D (GLSL) and Value Cubic Noise 3D (GLSL and HLSL)

### DIFF
--- a/GLSL/FastNoiseLite.glsl
+++ b/GLSL/FastNoiseLite.glsl
@@ -1446,7 +1446,7 @@ float _fnlSingleValueCubic3D(int seed, FNLfloat x, FNLfloat y, FNLfloat z)
             _fnlCubicLerp(_fnlValCoord3D(seed, x0, y2, z3), _fnlValCoord3D(seed, x1, y2, z3), _fnlValCoord3D(seed, x2, y2, z3), _fnlValCoord3D(seed, x3, y2, z3), xs),
             _fnlCubicLerp(_fnlValCoord3D(seed, x0, y3, z3), _fnlValCoord3D(seed, x1, y3, z3), _fnlValCoord3D(seed, x2, y3, z3), _fnlValCoord3D(seed, x3, y3, z3), xs),
             ys),
-        zs) * (1.f / 1.5f * 1.5f * 1.5f);
+        zs) * (1.f / (1.5f * 1.5f * 1.5f));
 }
 
 

--- a/GLSL/FastNoiseLite.glsl
+++ b/GLSL/FastNoiseLite.glsl
@@ -787,8 +787,8 @@ float _fnlSingleOpenSimplex2S2D(int seed, FNLfloat x, FNLfloat y)
     float y0 = yi - t;
 
     int aMask = int((xi + yi + 1.f) * -0.5f);
-    int bMask = int((xi - float(aMask) + 2.f) * 0.5f - yi);
-    int cMask = int((yi - float(aMask) + 2.f) * 0.5f - xi);
+    int bMask = int((xi - (float(aMask) + 2.f)) * 0.5f - yi);
+    int cMask = int((yi - (float(aMask) + 2.f)) * 0.5f - xi);
 
     float a0 = (2.f / 3.f) - x0 * x0 - y0 * y0;
     float value = (a0 * a0) * (a0 * a0) * _fnlGradCoord2D(seed, i, j, x0, y0);

--- a/HLSL/FastNoiseLite.hlsl
+++ b/HLSL/FastNoiseLite.hlsl
@@ -1714,7 +1714,7 @@ static float _fnlSingleValueCubic3D(int seed, FNLfloat x, FNLfloat y, FNLfloat z
             _fnlCubicLerp(_fnlValCoord3D(seed, x0, y2, z3), _fnlValCoord3D(seed, x1, y2, z3), _fnlValCoord3D(seed, x2, y2, z3), _fnlValCoord3D(seed, x3, y2, z3), xs),
             _fnlCubicLerp(_fnlValCoord3D(seed, x0, y3, z3), _fnlValCoord3D(seed, x1, y3, z3), _fnlValCoord3D(seed, x2, y3, z3), _fnlValCoord3D(seed, x3, y3, z3), xs),
             ys),
-        zs) * (1 / 1.5f * 1.5f * 1.5f);
+        zs) * (1 / (1.5f * 1.5f * 1.5f));
 }
 
 // Value noise


### PR DESCRIPTION
Dear developers of FastNoiseLite Libruary.
I am working on custom plugin for Godot Game Engine that will allow usage of FastNoiseLite libruary on GPU device to provide noise data at runtime without visible delays and freezes.

I runned some tests in Godot and Shadertoy and found a few bugs in `_fnlSingleOpenSimplex2S2D` (In GLSL version only) and `_fnlSingleValueCubic3D` (In GLSL and HLSL versions) functions.

OpenSimplex2S Noise 2D (GLSL) before bug fix:
![image](https://github.com/Auburn/FastNoiseLite/assets/56871670/ad4e3477-bd93-40cd-ba1e-6ab9c57a2465)

After bug fix:
![image](https://github.com/Auburn/FastNoiseLite/assets/56871670/3d705d3b-99f7-4f22-8ee0-e652b159961f)


Value Cubic Noise 3D  (GLSL) before bug fix:
![image](https://github.com/Auburn/FastNoiseLite/assets/56871670/decc74ea-6e64-40f1-92f8-585d3b4cc958)

After bug fix (equal to output of C++ and https://auburn.github.io/FastNoiseLite/ versions):
![image](https://github.com/Auburn/FastNoiseLite/assets/56871670/3c22154e-6582-4b67-a1da-93eb0f288019)


According to my current tests - other Noises (and functions) in GLSL are 99.9% equal to Noises created by C++ version of FastNoiseLite provided by Godot:
![image](https://github.com/Auburn/FastNoiseLite/assets/56871670/92143286-2b9e-4e3e-b6c5-f72e80da4276)

If I found more bugs during plugin development I will try to inform you about them and seek for posible solutions...

Thank you for your attention and sorry for my bad English. Good luck in future development.

P.S. : Code I created for Shadertoy(https://www.shadertoy.com/)  for testing and demonstration:
[FastNoiseLite-ShadertoyTest.txt](https://github.com/Auburn/FastNoiseLite/files/13814340/FastNoiseLite-ShadertoyTest.txt)
