### PR TITLE
Add missing parens in C variant of SingleValueCubic3D

### DIFF
--- a/C/FastNoiseLite.h
+++ b/C/FastNoiseLite.h
@@ -1825,7 +1825,7 @@ static float _fnlSingleValueCubic3D(int seed, FNLfloat x, FNLfloat y, FNLfloat z
             _fnlCubicLerp(_fnlValCoord3D(seed, x0, y2, z3), _fnlValCoord3D(seed, x1, y2, z3), _fnlValCoord3D(seed, x2, y2, z3), _fnlValCoord3D(seed, x3, y2, z3), xs),
             _fnlCubicLerp(_fnlValCoord3D(seed, x0, y3, z3), _fnlValCoord3D(seed, x1, y3, z3), _fnlValCoord3D(seed, x2, y3, z3), _fnlValCoord3D(seed, x3, y3, z3), xs),
             ys),
-        zs) * (1 / 1.5f * 1.5f * 1.5f);
+        zs) * (1 / (1.5f * 1.5f * 1.5f));
 }
 
 // Value noise


### PR DESCRIPTION
Accidentally used C variant as a test oracle for my port of the library, and this typo threw a lil spoke into my wheels.